### PR TITLE
update README.md to define sOTU and cite deblur

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your conda installation might fail with a 'PackagesNotFoundError' message. This 
 
 <img src="Example/denovoArtifacts.png">
 
-Beta diversity was computed for all 599 samples of [this study](https://qiita.ucsd.edu/study/description/10422) (manuscript in preparation) on the deblur table rarefied to 5,870 sequences per sample with 4,727 sOTUs total as unweighted unifrac distance with three alternative phylogenetic trees:
+Beta diversity was computed for all 599 samples of [this study](https://qiita.ucsd.edu/study/description/10422) (manuscript in preparation) on the deblur table rarefied to 5,870 sequences per sample with 4,727 sub-operational-taxonomic-units ([sOTU](http://msystems.asm.org/content/2/2/e00191-16) total as unweighted unifrac distance with three alternative phylogenetic trees:
 
   A) De-novo by aligning 249nt long fragments via mafft and inferring a tree via fasttree - as suggested in the QIIME 2 "moving pictures" [tutorial](https://docs.qiime2.org/2017.10/tutorials/moving-pictures/#generate-a-tree-for-phylogenetic-diversity-analyses). Strong separation between observed clusters cannot be explained by any metadata, but the relative abundance of three sOTUs belonging to the genus *Methanobrevibacter*: not detectable in lower gray cluster, very low abundant in upper coloured cluster.
 


### PR DESCRIPTION
I just discovered this project, and when reading the overview, I had to look up "sOTU." I know there is lots of names for ASVs, DSVs, zOTUs, sOTUs etc, and I so I have added a definition to the readme.

If this method is specific to deblur or developed with deblur in mind, we could specify this too.