### PR TITLE
Add debug flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ before_install:
   - conda info -a
 install:
   #- conda create -q -n test-env --file https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-conda-linux-64.txt
-  - wget https://data.qiime2.org/distro/core/qiime2-2018.4-py35-linux-conda.yml
-  - travis_retry conda env create -n test-env --file qiime2-2018.4-py35-linux-conda.yml
-  - rm qiime2-2018.4-py35-linux-conda.yml
+  - wget -q https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-py35-linux-conda.yml
+  - conda env create -q -n test-env --file qiime2-latest-py35-linux-conda.yml
+  #- wget https://data.qiime2.org/distro/core/qiime2-2018.4-py35-linux-conda.yml
+  #- travis_retry conda env create -n test-env --file qiime2-2018.4-py35-linux-conda.yml
+  #- rm qiime2-2018.4-py35-linux-conda.yml
   - source activate test-env
   - conda install -q nose
   - pip install -q https://github.com/qiime2/q2lint/archive/master.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@ before_install:
   - conda info -a
 install:
   #- conda create -q -n test-env --file https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-conda-linux-64.txt
-  - wget -q https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-py35-linux-conda.yml
-  - conda env create -q -n test-env --file qiime2-latest-py35-linux-conda.yml
-  #- wget https://data.qiime2.org/distro/core/qiime2-2018.4-py35-linux-conda.yml
-  #- travis_retry conda env create -n test-env --file qiime2-2018.4-py35-linux-conda.yml
-  #- rm qiime2-2018.4-py35-linux-conda.yml
+  - wget https://data.qiime2.org/distro/core/qiime2-2018.4-py35-linux-conda.yml
+  - travis_retry conda env create -n test-env --file qiime2-2018.4-py35-linux-conda.yml
+  - rm qiime2-2018.4-py35-linux-conda.yml
   - source activate test-env
   - conda install -q nose
   - pip install -q https://github.com/qiime2/q2lint/archive/master.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # q2-fragment-insertion changelog
 
-## Version 2018.4.0 (changes since 0.1.0 go here)
+## Version 2018.6.0 (changes since 0.1.0 go here)
 
 * added function `filter-features` which takes a feature-table and a phylogeny and filters the table down to those features also included in the phylogeny. This becomes a standard tasks, since e.g. Deblur produces fragments that do not get inserted into the reference phylogeny by SEPP, but those features would cause errors in downstream diversity computation. Also see [QIIME2 forum discussion](https://forum.qiime2.org/t/filter-feature-table-phylogenetically/4462)
-* adopted to QIIME2 version numbers.
 
-## feature requests, not yet implemented
+* adopted to QIIME2 version numbers.
 
 * added `--debug` option, which together with `--verbose` will allow inspection of additional information of a SEPP run for further debugging. See [QIIME2 forum discussion](https://forum.qiime2.org/t/pass-verbose-flag-to-executable/4461)
 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '2018.4.0' %}
+{% set version = '2018.6.0' %}
 {% set qiime2release = '2017.12' %}
 
 package:
@@ -21,7 +21,7 @@ requirements:
     - python 3.5*
     - setuptools
     - nodejs
-    - fragment-insertion
+    - fragment-insertion >=4.3.5
     - biom-format >=2.1.5,<2.2.0
     - qiime2 >={{ qiime2release }}.*
     - q2templates >={{ qiime2release }}.*
@@ -32,7 +32,7 @@ requirements:
     - python 3.5*
     - setuptools
     - nodejs
-    - fragment-insertion
+    - fragment-insertion >=4.3.5
     - biom-format >=2.1.5,<2.2.0
     - qiime2 >={{ qiime2release }}.*
     - q2templates >={{ qiime2release }}.*

--- a/q2_fragment_insertion/_insertion.py
+++ b/q2_fragment_insertion/_insertion.py
@@ -118,7 +118,8 @@ def _obtain_taxonomy(filename_tree: str,
 
 def _run(seqs_fp, threads, cwd, alignment_subset_size, placement_subset_size,
          reference_alignment: AlignedDNASequencesDirectoryFormat=None,
-         reference_phylogeny: NewickFormat=None):
+         reference_phylogeny: NewickFormat=None,
+         debug: bool=False):
     cmd = ['run-sepp.sh',
            seqs_fp,
            'q2-fragment-insertion',
@@ -130,6 +131,8 @@ def _run(seqs_fp, threads, cwd, alignment_subset_size, placement_subset_size,
             '-a', str(reference_alignment.file.view(AlignedDNAFASTAFormat))])
     if reference_phylogeny is not None:
         cmd.extend(['-t', str(reference_phylogeny)])
+    if debug:
+        cmd.extend(['-b', '1'])
 
     subprocess.run(cmd, check=True, cwd=cwd)
 
@@ -151,7 +154,8 @@ def sepp(representative_sequences: DNASequencesDirectoryFormat,
          alignment_subset_size: int=1000,
          placement_subset_size: int=5000,
          reference_alignment: AlignedDNASequencesDirectoryFormat=None,
-         reference_phylogeny: NewickFormat=None
+         reference_phylogeny: NewickFormat=None,
+         debug: bool=False,
          ) -> (NewickFormat, PlacementsFormat):
 
     _sanity()
@@ -172,7 +176,7 @@ def sepp(representative_sequences: DNASequencesDirectoryFormat,
         _run(str(representative_sequences.file.view(DNAFASTAFormat)),
              str(threads), tmp,
              str(alignment_subset_size), str(placement_subset_size),
-             reference_alignment, reference_phylogeny)
+             reference_alignment, reference_phylogeny, debug)
         outtree = os.path.join(tmp, tree)
         outplacements = os.path.join(tmp, placements)
 

--- a/q2_fragment_insertion/citations.bib
+++ b/q2_fragment_insertion/citations.bib
@@ -1,0 +1,10 @@
+@article{SEPP,
+  title={Phylogenetic Placement of Exact Amplicon Sequences Improves Associations with Clinical Information},
+	author={Janssen, Stefan and McDonald, Daniel and Gonzalez, Antonio and Navas-Molina, Jose A. and Jiang, Lingjing and Xu, Zhenjiang Zech and Winker, Kevin and Kado, Deborah M. and Orwoll, Eric and Manary, Mark and Mirarab, Siavash and Knight, Rob},
+  journal={mSystems},
+  volume={3},
+  number={3},
+  year={2018},
+  publisher={American Society for Microbiology Journals},
+  doi={10.1128/mSystems.00021-18},
+}

--- a/q2_fragment_insertion/plugin_setup.py
+++ b/q2_fragment_insertion/plugin_setup.py
@@ -17,6 +17,7 @@ import q2_fragment_insertion as q2fi
 from q2_fragment_insertion._type import Placements
 from q2_fragment_insertion._format import (PlacementsFormat, PlacementsDirFmt)
 
+
 plugin = qiime2.plugin.Plugin(
     name='fragment-insertion',
     version=q2fi.__version__,

--- a/q2_fragment_insertion/plugin_setup.py
+++ b/q2_fragment_insertion/plugin_setup.py
@@ -8,7 +8,6 @@
 import importlib
 
 import qiime2.plugin
-from qiime2.plugin import Citations
 from q2_types.feature_data import (FeatureData, Sequence, AlignedSequence,
                                    Taxonomy)
 from q2_types.feature_table import (FeatureTable, Frequency)
@@ -18,7 +17,6 @@ import q2_fragment_insertion as q2fi
 from q2_fragment_insertion._type import Placements
 from q2_fragment_insertion._format import (PlacementsFormat, PlacementsDirFmt)
 
-citations = Citations.load('citations.bib', package='q2_fragment_insertion')
 plugin = qiime2.plugin.Plugin(
     name='fragment-insertion',
     version=q2fi.__version__,
@@ -98,8 +96,7 @@ plugin.methods.register_function(
     name=('Insert fragment sequences using SEPP into reference phylogenies '
           'like Greengenes 13_8'),
     description=('Perform fragment insertion of 16S sequences using the SEPP '
-                 'algorithm against the Greengenes 13_8 99% tree.'),
-    citations=[citations['SEPP']]
+                 'algorithm against the Greengenes 13_8 99% tree.')
 )
 
 

--- a/q2_fragment_insertion/plugin_setup.py
+++ b/q2_fragment_insertion/plugin_setup.py
@@ -8,6 +8,7 @@
 import importlib
 
 import qiime2.plugin
+from qiime2.plugin import Citations
 from q2_types.feature_data import (FeatureData, Sequence, AlignedSequence,
                                    Taxonomy)
 from q2_types.feature_table import (FeatureTable, Frequency)
@@ -17,7 +18,7 @@ import q2_fragment_insertion as q2fi
 from q2_fragment_insertion._type import Placements
 from q2_fragment_insertion._format import (PlacementsFormat, PlacementsDirFmt)
 
-
+citations = Citations.load('citations.bib', package='q2_fragment_insertion')
 plugin = qiime2.plugin.Plugin(
     name='fragment-insertion',
     version=q2fi.__version__,
@@ -55,7 +56,11 @@ _parameter_descriptions = {
      'subset is set to make sure the memory requirement of the pplacer step '
      'does not become prohibitively large.\nFurther reading: '
      'https://github.com/smirarab/sepp/blob/master/tutorial/sepp-tutorial.md'
-     '#sample-datasets-default-parameters')}
+     '#sample-datasets-default-parameters'),
+    'debug':
+    ('Print additional run information to STDOUT for debugging. '
+     'Run together with --verbose to actually see the information on STDOUT. '
+     'Temporary directories will not be removed if run fails.')}
 
 _output_descriptions = {
     'tree': 'The tree with inserted feature data'}
@@ -63,7 +68,9 @@ _output_descriptions = {
 
 _parameters = {'threads': qiime2.plugin.Int,
                'alignment_subset_size': qiime2.plugin.Int,
-               'placement_subset_size': qiime2.plugin.Int}
+               'placement_subset_size': qiime2.plugin.Int,
+               'debug': qiime2.plugin.Bool
+               }
 
 
 _outputs = [('tree', Phylogeny[Rooted]),
@@ -91,7 +98,8 @@ plugin.methods.register_function(
     name=('Insert fragment sequences using SEPP into reference phylogenies '
           'like Greengenes 13_8'),
     description=('Perform fragment insertion of 16S sequences using the SEPP '
-                 'algorithm against the Greengenes 13_8 99% tree.')
+                 'algorithm against the Greengenes 13_8 99% tree.'),
+    citations=[citations['SEPP']]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 from setuptools import setup, find_packages
 
+
 setup(
     name="q2-fragment-insertion",
     version="2018.6.0",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     },
     license='BSD-3-Clause',
     package_data={
-        'q2_fragment_insertion.tests': ['data/*']}
-        'q2_fragment_insertion': ['citations.bib'],
+        'q2_fragment_insertion.tests': ['data/*'],
+        'q2_fragment_insertion': ['citations.bib']}
 )

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     name="q2-fragment-insertion",
     version="2018.6.0",
     packages=find_packages(),
-    author="Daniel McDonald",
-    author_email="wasade@gmail.com",
+    author="Stefan Janssen",
+    author_email="stefan.m.janssen@gmail.com",
     description="Fragment insertion into existing phylogenies",
     entry_points={
         "qiime2.plugins":

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 from setuptools import setup, find_packages
 
-
 setup(
     name="q2-fragment-insertion",
     version="2018.6.0",

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,5 @@ setup(
     license='BSD-3-Clause',
     package_data={
         'q2_fragment_insertion.tests': ['data/*']}
+        'q2_fragment_insertion': ['citations.bib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-fragment-insertion",
-    version="2018.4.0",
+    version="2018.6.0",
     packages=find_packages(),
     author="Daniel McDonald",
     author_email="wasade@gmail.com",
@@ -19,8 +19,10 @@ setup(
         "qiime2.plugins":
         ["q2-fragment-insertion=q2_fragment_insertion.plugin_setup:plugin"]
     },
+    url="https://github.com/biocore/q2-fragment-insertion",
     license='BSD-3-Clause',
     package_data={
-        'q2_fragment_insertion.tests': ['data/*'],
-        'q2_fragment_insertion': ['citations.bib']}
+        'q2_fragment_insertion': ['citations.bib'],
+        'q2_fragment_insertion.tests': ['data/*']
+    }
 )


### PR DESCRIPTION
If user raises `--p-debug` together with `--verbose`, SEPP will print logfiles in internal debug mode to STDOUT and NOT delete temporary directories if the run exists non zero. Thus, debugging will become much easier.
I also added a default citation which should be integrated into produced artifacts.

Please also have a look at https://forum.qiime2.org/t/pass-verbose-flag-to-executable/4461/10 for design decisions.