### PR TITLE
simplify install process by including channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 
 Once QIIME2 is [installed](https://docs.qiime2.org/2018.2/install/), and you activated your QIIME2 environment, it should be possible to install `q2-fragment-insertion` with:
 
-    conda install -c https://conda.anaconda.org/biocore q2-fragment-insertion
-    qiime dev refresh-cache
-    
-**Troubleshoot 'PackagesNotFoundError':**
-Your conda installation might fail with a 'PackagesNotFoundError' message. This is most likely due to missing channels. Try to re-run the above command with explicit addition of four more channels:
-
     conda install -c anaconda -c defaults -c conda-forge -c bioconda -c https://conda.anaconda.org/biocore q2-fragment-insertion
     qiime dev refresh-cache
 


### PR DESCRIPTION
Simplify install process by including channels in initial command (rather than as a troubleshooting step) so we're not making assumptions about the user's conda setup. I don't think it ever hurts to include the channels in the install command (please correct me if I'm wrong about that), so might as well include them here. Users who have just followed the QIIME 2 install commands won't have any default channels specified, so they'll always hit the `PackagesNotFound` error. 